### PR TITLE
Quick fix to avoid multiple default storage classes

### DIFF
--- a/templates/aws-ebs-storage-classes.yaml
+++ b/templates/aws-ebs-storage-classes.yaml
@@ -30,7 +30,7 @@ objects:
     apiVersion: storage.k8s.io/v1
     metadata:
       annotations:
-        storageclass.beta.kubernetes.io/is-default-class: "true"
+        storageclass.beta.kubernetes.io/is-default-class: "false"
       name: slow-block
     parameters:
       encrypted: "${ENCRYPT_STORAGE}"


### PR DESCRIPTION
Currently we end up with multiple default storage classes. This is a quick fix and should be revisited later.