### PR TITLE
Prereqs no longer exist

### DIFF
--- a/RHTE-LAB.adoc
+++ b/RHTE-LAB.adoc
@@ -543,19 +543,6 @@ Receiving objects: 100% (888/888), 1.45 MiB | 174.00 KiB/s, done.
 Resolving deltas: 100% (412/412), done.
 --------------------------------------------------------------------------------
 
-. Process the Eunomia prerequisites with `helm template` and pass the output resource definitions to `oc apply`:
-+
-[subs=+quotes]
---------------------------------------------------------------------------------
-$ *helm template eunomia/deploy/helm/prereqs/ | oc apply -f -*
-namespace/eunomia-operator created
-customresourcedefinition.apiextensions.k8s.io/gitopsconfigs.eunomia.kohls.io created
-clusterrole.rbac.authorization.k8s.io/gitopsconfig-admin created
-clusterrole.rbac.authorization.k8s.io/gitopsconfig-viewer created
-clusterrole.rbac.authorization.k8s.io/eunomia-operator created
-clusterrolebinding.rbac.authorization.k8s.io/eunomia-operator created
---------------------------------------------------------------------------------
-
 . Process the Eunomia operator directory with `helm template` and pass the output resource definitions to `oc apply`:
 +
 [subs=+quotes]


### PR DESCRIPTION
Removed the prereqs documentation as they no longer seem to exist on Eunomia install docs (or repo)