### PR TITLE
Fix Helm Usage update on Section 1.4 Step 3

### DIFF
--- a/RHTE-LAB.adoc
+++ b/RHTE-LAB.adoc
@@ -547,7 +547,9 @@ Resolving deltas: 100% (412/412), done.
 +
 [subs=+quotes]
 --------------------------------------------------------------------------------
-$ *helm template eunomia/deploy/helm/prereqs/ | oc apply -f -*
+$ *helm template deploy/helm/eunomia-operator/ --set openshift.route.enabled=true | oc apply -f -*
+
+
 namespace/eunomia-operator created
 customresourcedefinition.apiextensions.k8s.io/gitopsconfigs.eunomia.kohls.io created
 clusterrole.rbac.authorization.k8s.io/gitopsconfig-admin created


### PR DESCRIPTION
Instructions referred to stale usage command: 

Instead of: 
  helm template eunomia/deploy/helm/prereqs/ | oc apply -f -

Use:  
  helm template deploy/helm/eunomia-operator/ --set openshift.route.enabled=true | oc apply -f -